### PR TITLE
Added force option via v1.12.0.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,4 +59,5 @@ jobs:
           dir: build
           skip-unpublish: true
           skip-purge: true
+          force: true
           chunk-size: 10

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ skip-purge:
   description: 'Skip automatic purge of cached assets in CDN'
   required: false
   default: false
+force:
+  description: 'Force the deployment of assets (skip md5 check)'
+  required: false
+  default: false
 chunk-size:
   description: 'Alter the concurrency of deployment'
   required: false

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Skip automatic purge of cached assets in CDN'
     required: false
     default: false
+  force:
+    description: 'Force the deployment of assets (skip md5 check)'
+    required: false
+    default: false
   chunk-size:
     description: 'Alter the concurrency of deployment'
     required: false
@@ -41,7 +45,7 @@ inputs:
     default: 'https://api.quantcdn.io'
 runs:
   using: "docker"
-  image: "docker://quantcdn/cli:1.10.0"
+  image: "docker://quantcdn/cli:1.12.0"
   entrypoint: quant
   args:
     - deploy
@@ -53,6 +57,7 @@ runs:
     - --skip-unpublish=${{ inputs.skip-unpublish }}
     - --skip-unpublish-regex="${{ inputs.skip-unpublish-regex }}"
     - --skip-purge=${{ inputs.skip-purge }}
+    - --force=${{ inputs.force }}
     - --chunk-size=${{ inputs.chunk-size }}
     - --endpoint=${{ inputs.endpoint }}
 branding:


### PR DESCRIPTION
* Bumps CLI to `1.12.0`
* Improves metadata lookup performance
* Adds `--force` flag option
* Ensures content (markup) does not have revision lookup applied so item is always included in search index process