### PR TITLE
Upgrade to Quant CLI v6 and actions/checkout v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare a test file
         run: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare a test file
         run: |
@@ -65,7 +65,7 @@ jobs:
   test-functions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Create test functions
       - name: Prepare test functions

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Deploy to QuantCDN Action
 
-This GitHub Action deploys your static site and/or functions to QuantCDN using the Quant CLI v5.
+This GitHub Action deploys your static site and/or functions to QuantCDN using the Quant CLI v6.
 
 ## Usage
 
 ### Deploy Assets
 ```yaml
-- uses: quantcdn/action-deploy@v5
+- uses: quantcdn/action-deploy@v6
   with:
     customer: your-customer-id
     project: your-project-name
@@ -16,7 +16,7 @@ This GitHub Action deploys your static site and/or functions to QuantCDN using t
 
 ### Deploy Functions
 ```yaml
-- uses: quantcdn/action-deploy@v5
+- uses: quantcdn/action-deploy@v6
   with:
     customer: your-customer-id
     project: your-project-name
@@ -56,7 +56,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Build site
         run: |
@@ -64,7 +64,7 @@ jobs:
           npm run build
           
       - name: Deploy to QuantCDN
-        uses: quantcdn/action-deploy@v5
+        uses: quantcdn/action-deploy@v6
         with:
           customer: your-customer-id
           project: your-project-name
@@ -109,10 +109,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Deploy Functions
-        uses: quantcdn/action-deploy@v5
+        uses: quantcdn/action-deploy@v6
         with:
           customer: your-customer-id
           project: your-project-name
@@ -132,7 +132,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Build site
         run: |
@@ -140,7 +140,7 @@ jobs:
           npm run build
           
       - name: Deploy to QuantCDN
-        uses: quantcdn/action-deploy@v5
+        uses: quantcdn/action-deploy@v6
         with:
           customer: your-customer-id
           project: your-project-name
@@ -151,7 +151,7 @@ jobs:
 
 ## Notes
 
-- This action uses Quant CLI v5
+- This action uses Quant CLI v6
 - For search functionality, please use the dedicated search action
 - Make sure your `QUANT_TOKEN` is stored securely in your repository secrets
 

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
   steps:
     - name: Deploy Functions
       if: inputs.functions != ''
-      uses: "docker://quantcdn/cli:5.1.1"
+      uses: "docker://quantcdn/cli:6.0.0"
       env:
         CUSTOMER: ${{ inputs.customer }}
         TOKEN: ${{ inputs.token }}
@@ -71,7 +71,7 @@ runs:
 
     - name: Deploy Assets
       if: inputs.dir != ''
-      uses: "docker://quantcdn/cli:5.1.1"
+      uses: "docker://quantcdn/cli:6.0.0"
       with:
         args: >
           deploy


### PR DESCRIPTION
## Summary
- Update Docker image to `quantcdn/cli:6.0.0`
- Modernize GitHub Actions to use `actions/checkout@v6`
- Update README documentation to reflect v6

## Test plan
- [x] Verify CI passes with new CLI version
- [x] Test deployment with updated action