### PR TITLE
Bump CLI to v6.1.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
   steps:
     - name: Deploy Functions
       if: inputs.functions != ''
-      uses: "docker://quantcdn/cli:6.0.0"
+      uses: "docker://quantcdn/cli:6.1.0"
       env:
         CUSTOMER: ${{ inputs.customer }}
         TOKEN: ${{ inputs.token }}
@@ -71,7 +71,7 @@ runs:
 
     - name: Deploy Assets
       if: inputs.dir != ''
-      uses: "docker://quantcdn/cli:6.0.0"
+      uses: "docker://quantcdn/cli:6.1.0"
       with:
         args: >
           deploy


### PR DESCRIPTION
## Summary
- Bumps `quantcdn/cli` Docker image from 6.0.0 to 6.1.0
- Fixes revision log not storing successful uploads (was requiring two no-change deploys to fully populate)
- Fixes `--endpoint` CLI argument being ignored during `quant init`
- Async MD5 hashing for better parallelism within chunks

## Release
https://github.com/quantcdn/quant-cli/releases/tag/v6.1.0